### PR TITLE
fix: 修复快速输入时Tab键补全出错

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -7,11 +7,9 @@ export {}
 
 declare module '@vue/runtime-core' {
   export interface GlobalComponents {
-    ACol: typeof import('ant-design-vue/es')['Col']
     ACollapse: typeof import('ant-design-vue/es')['Collapse']
     ACollapsePanel: typeof import('ant-design-vue/es')['CollapsePanel']
     AInput: typeof import('ant-design-vue/es')['Input']
-    ARow: typeof import('ant-design-vue/es')['Row']
     ATag: typeof import('ant-design-vue/es')['Tag']
     ContentOutput: typeof import('./src/components/yu-terminal/ContentOutput.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']

--- a/src/components/yu-terminal/YuTerminal.vue
+++ b/src/components/yu-terminal/YuTerminal.vue
@@ -332,6 +332,8 @@ const isInputFocused = () => {
  * 设置输入框的值
  */
 const setTabCompletion = () => {
+  // 手动触发hint
+  setHint(inputCommand.value.text)
   if(hint.value){
     inputCommand.value.text =`${hint.value.split(' ')[0]}${hint.value.split(' ').length > 1 ? ' ' : ''}`
   }


### PR DESCRIPTION
https://github.com/liyupi/yuindex/pull/22 实现了 Tab 补全，但在使用中我发现了一个 Bug：

当我输入“p” 时，提示为 pwd。当我继续输入 “in” 后立刻按下 Tab 键，我期望可以自动补全得到“ping”，此
时提示还未更新，但程序直接把原来的提示（也就是 pwd）更新到了控制台。
