### PR TITLE
修复并优化ping命令&执行命令时禁止用户输入

### DIFF
--- a/src/components/yu-terminal/YuTerminal.vue
+++ b/src/components/yu-terminal/YuTerminal.vue
@@ -60,6 +60,7 @@
       </a-collapse>
       <div class="terminal-row">
         <a-input
+          :disabled="runningState().isRunning"
           ref="commandInputRef"
           v-model:value="inputCommand.text"
           class="command-input"
@@ -74,8 +75,11 @@
         </a-input>
       </div>
       <!-- 输入提示-->
-      <div v-if="hint" class="terminal-row" style="color: #bbb">
+      <div v-if="hint&&!runningState().isRunning" class="terminal-row" style="color: #bbb">
         hint：{{ hint }}
+      </div>
+      <div v-if="runningState().isRunning" class="terminal-spin" style="color: #bbb">
+        <a-spin :indicator="indicator" />命令执行中，请稍候
       </div>
       <div style="margin-bottom: 16px" />
     </div>
@@ -97,6 +101,7 @@ import { useTerminalConfigStore } from "../../core/commands/terminal/config/term
 import useHint from "./hint";
 import UserType = User.UserType;
 import { LOCAL_USER } from "../../core/commands/user/userConstant";
+import { defineStore } from 'pinia'
 
 interface YuTerminalProps {
   height?: string | number;
@@ -158,6 +163,7 @@ const { hint, setHint, debounceSetHint } = useHint();
  * 提交命令（回车）
  */
 const doSubmitCommand = async () => {
+  runningState().isRunning = true;
   setHint("");
   let inputText = inputCommand.value.text;
   // 执行某条历史命令
@@ -193,6 +199,7 @@ const doSubmitCommand = async () => {
   setTimeout(() => {
     terminalRef.value.scrollTop = terminalRef.value.scrollHeight;
   }, 50);
+  runningState().isRunning = false;
 };
 
 // 输入框内容改变时，触发输入提示
@@ -373,6 +380,15 @@ const terminal: TerminalType = {
   toggleAllCollapse,
   setCommandCollapsible,
 };
+
+/**
+ * 运行状态
+ */
+const runningState = defineStore("runningState", {
+  state: () => {
+    return { isRunning: false };
+  },
+});
 
 /**
  * 只执行一次

--- a/src/components/yu-terminal/YuTerminal.vue
+++ b/src/components/yu-terminal/YuTerminal.vue
@@ -79,7 +79,7 @@
         hint：{{ hint }}
       </div>
       <div v-if="runningState().isRunning" class="terminal-spin" style="color: #bbb">
-        <a-spin :indicator="indicator" />命令执行中，请稍候
+        <a-spin />命令执行中，请稍候
       </div>
       <div style="margin-bottom: 16px" />
     </div>

--- a/src/core/commandExecutor.ts
+++ b/src/core/commandExecutor.ts
@@ -15,6 +15,8 @@ export const doCommandExecute = async (
   terminal: TerminalType,
   parentCommand?: CommandType
 ) => {
+  //去除命令首尾空格
+  text = text.replace(/(^\s*)|(\s*$)/g,"");
   if (!text) {
     return;
   }

--- a/src/core/commandExecutor.ts
+++ b/src/core/commandExecutor.ts
@@ -16,7 +16,7 @@ export const doCommandExecute = async (
   parentCommand?: CommandType
 ) => {
   //去除命令首尾空格
-  text = text.replace(/(^\s*)|(\s*$)/g,"");
+  text = text.trim();
   if (!text) {
     return;
   }

--- a/src/core/commands/pingCommand.ts
+++ b/src/core/commands/pingCommand.ts
@@ -16,24 +16,47 @@ const pingCommand: CommandType = {
       required: true,
     },
   ],
-  options: [],
+  options: [
+    {
+      key: "timeout",
+      desc: "请求超时时间(单位:毫秒)",
+      alias: ["t"],
+      type: "string",
+      defaultValue: "3000",
+    },
+  ],
   async action(options, terminal) {
     const { _ } = options;
+    const { timeout = "3000" } = options;
     if (_.length < 1) {
       terminal.writeTextErrorResult("参数不足");
       return;
     }
     var dest = _[0];
     if (
-      dest.substr(0, 7).toLowerCase() != "http://" &&
-      dest.substr(0, 8).toLowerCase() != "https://"
+      !dest.toLowerCase().startsWith("http://") &&
+      !dest.toLowerCase().startsWith("https://")
     ) {
-      dest = "http://" + dest;
+      dest = "https://" + dest;
     }
-    const res = await fetch(dest, { mode: "no-cors" })
-      .then((resp) => {
+    if (dest.toLowerCase().startsWith("http://")) {
+      dest = dest.replace("http://", "https://");
+    }
+    const startTime = new Date().getTime();
+    const res = await Promise.race([
+      new Promise(function (resolve, reject) {
+        setTimeout(() => reject(new Error("timeout")), Number(timeout));
+      }),
+      fetch(dest, { mode: "no-cors" }),
+    ])
+      .then((resp: any) => {
         if (resp.ok || resp.status == 200 || resp.type == "opaque") {
+          console.log(resp);
+          const finishTime = new Date().getTime();
           terminal.writeTextSuccessResult("目标地址正常");
+          terminal.writeTextResult(
+            `延迟=${(finishTime - startTime).toString()}ms`
+          );
         } else {
           terminal.writeTextErrorResult("ping 不通！");
         }

--- a/src/core/commands/pingCommand.ts
+++ b/src/core/commands/pingCommand.ts
@@ -47,7 +47,7 @@ const pingCommand: CommandType = {
       new Promise(function (resolve, reject) {
         setTimeout(() => reject(new Error("timeout")), Number(timeout));
       }),
-      fetch(dest, { mode: "no-cors" }),
+      fetch(dest, { mode: "no-cors", cache: "reload" }),
     ])
       .then((resp: any) => {
         if (resp.ok || resp.status == 200 || resp.type == "opaque") {


### PR DESCRIPTION
Ping命令：
1. 根据#40 中的建议使用startsWith()
2. 增加超时时间自定义(-t)，默认为3000ms（之前用的是fetch默认的超时时间，感觉有些过长）
3. 输出内容中增加延迟时间显示
4. **修复默认使用http导致的Mixed Content，强制使用https**

YuTerminal：
1. 执行命令时禁止用户输入，防止用户认为没反应而重复执行
2. 执行命令过程中增加提示
3. 删除所提交命令首尾的空格，当前好像只在hint中做了处理。例如当前输入“he"后按tab会将命令补全为“help ”此时不输入任何参数提交会报错；还有在linux终端里输入若干空格提交后应当不会产生任何结果，当前会报错。