### PR TITLE
feat:添加electron支持打包为桌面端应用

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,23 @@
   "description": "极客范儿的浏览器主页",
   "private": true,
   "version": "0.0.0",
+  "main": "public/main.js",
   "scripts": {
     "dev": "vite",
     "dev:crx": "cross-env BUILD_CRX=1 vite build --watch",
     "build": "vue-tsc --noEmit && vite build",
     "build:crx": "cross-env BUILD_CRX=1 vite build",
+    "build:electron": "vite build & electron-builder",
     "preview": "vite preview",
+    "preview:electron": "electron .",
     "tsc": "vue-tsc --noEmit"
+  },
+  "build": {
+    "appId": "cloudDoc",
+    "productName": "yuindex",
+    "directories": {
+      "output": "electron-builder"
+    }
   },
   "dependencies": {
     "ant-design-vue": "^3.2.10",
@@ -48,6 +58,8 @@
     "typescript": "^4.6.4",
     "unplugin-vue-components": "^0.21.1",
     "vite": "^2.9.9",
-    "vue-tsc": "^0.38.4"
+    "vue-tsc": "^0.38.4",
+    "electron": "^20.0.2",
+    "electron-builder": "^23.3.3"
   }
 }

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,55 @@
+const { app, BrowserWindow, screen, shell } = require("electron");
+const path = require("path");
+
+function createWindow() {
+  const { width: screenW } = screen.getPrimaryDisplay().workAreaSize;
+  const winW = 1000;
+  const winH = 800;
+  // Create the browser window.
+  const mainWindow = new BrowserWindow({
+    // 设置是否显示边框
+    // frame: false,
+    // transparent: true,
+    // hasShadow: true,
+    // 设置初始位置
+    x: screenW - winW,
+    y: 0,
+    // 设置透明度
+    // opacity:1,
+    width: winW,
+    height: winH,
+    // alwaysOnTop: true,
+    closable: true,
+    movable: true,
+    // resizable: true,
+    // enableLargerThanScreen: true,
+  });
+
+  // and load the index.html of the app.
+  mainWindow.loadFile("dist/index.html");
+  // mainWindow.loadURL('http://localhost:3000/')
+
+  // Open the DevTools.
+  // mainWindow.webContents.openDevTools();
+  // shell.beep()
+}
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on("activate", function () {
+    // On macOS it's common to re-create a window in the app when the
+    // dock icon is clicked and there are no other windows open.
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+// Quit when all windows are closed, except on macOS. There, it's common
+// for applications and their menu bar to stay active until the user quits
+// explicitly with Cmd + Q.
+app.on("window-all-closed", function () {
+  if (process.platform !== "darwin") app.quit();
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,9 +6,14 @@ import Components from "unplugin-vue-components/vite";
 import { AntDesignVueResolver } from "unplugin-vue-components/resolvers";
 // @ts-ignore
 import { chromeExtension } from "./build/chromeExtension";
+const path = require("path");
+
+let base = path.resolve(__dirname, "./dist");
+base = base.replace(/\\/g, "/");
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: process.env ? "" : base,
   plugins: [
     vue(),
     // 按需加载 ant-design-vue


### PR DESCRIPTION
添加electron支持，让这个项目可以作为一个桌面端应用运行。

说明：在进行electron构建前要先用vite打包。electron会根据dist中的打包文件进行构建。当然，也可以在public/main.js中做自己的配置。

两个命令：`preview:electron`预览，`build:electron`生成二进制安装文件