### PR TITLE
fix: 修复了windows下无法正常构建镜像的问题

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /src
 
 COPY . .
 
-RUN npm install
+RUN npm install --registry=https://registry.npmmirror.com
 
 RUN npm run build
 


### PR DESCRIPTION
如果是在Windows环境下编译开发后进行打包，`node_modules`下的包的环境是windows下的，构建镜像时直接拷贝会出问题，所以添加了一个`.dockerignore`文件，复制文件时忽略`node_modules`这个文件夹

然后在dockerfile中添加了对应的镜像源，加快了npm install的速度