### PR TITLE
修复异步操作后输入框光标不显示的问题

### DIFF
--- a/src/components/yu-terminal/YuTerminal.vue
+++ b/src/components/yu-terminal/YuTerminal.vue
@@ -275,6 +275,10 @@ const writeTextResult = (text: string, status?: OutputStatusType) => {
     status,
   };
   currentNewCommand.resultList.push(newOutput);
+  // 解决光标不显示问题
+  setTimeout(() => {
+    terminal.focusInput();
+  }, 0);
 };
 
 /**


### PR DESCRIPTION

问题 : 异步操作成功之后(一个命令调用了后端api之后),  输入框虽处于聚焦状态,  但是光标不进行显示。
![image](https://github.com/liyupi/yuindex/assets/105257778/2e689159-4f57-470d-bc13-195afea9b44b)

经过调试和网络搜索, 我发现问题很可能是由于异步操作影响了DOM元素的焦点状态，如果使用 setTimeout 来延迟设置输入框的焦点，就能有效地解决光标不显示的问题。setTimeout提供了足够的时间让浏览器处理完异步任务并重新渲染UI，从而恢复输入框的正常焦点状态和光标显示。

由于我们调用命令是要进行输出的, 因为我们就在终端的writeTextResult函数最后通过setTimeout(delay设置为0)调用终端的focusInput()方法, 之后再次执行命令, 光标成功显示。

![image](https://github.com/liyupi/yuindex/assets/105257778/36be41fe-c785-4066-8dfe-b8257581cfa8)


